### PR TITLE
Added Bosch Connectory Stuttgart witness

### DIFF
--- a/gather_raw_data.pl
+++ b/gather_raw_data.pl
@@ -160,6 +160,11 @@ foreach (@array_of_witnesses)#last timestamp
 		$witnesses_stats->{$_}->{status}="Exchange";
 		$others_value+=$witnesses_stats->{$_}->{validations_count};
 	}
+	elsif($_ eq '2TO6NYBGX3NF5QS24MQLFR7KXYAMCIE5'){
+		$witnesses_stats->{$_}->{text}="Bosch Connectory Stuttgart";
+		$witnesses_stats->{$_}->{status}="Independent Witness";
+		$others_value+=$witnesses_stats->{$_}->{validations_count};
+	}	
 	elsif ( grep( /^$buff$/, @default_witnesses ) ){
 		$witnesses_stats->{$_}->{text}="Tonych";
 		$witnesses_stats->{$_}->{status}="Founder's Witness";


### PR DESCRIPTION
Added 2TO6NYBGX3NF5QS24MQLFR7KXYAMCIE5 as a known witness node address of Bosch Connectory Stuttgart